### PR TITLE
Make Postiz independent and recoverable

### DIFF
--- a/.github/workflows/postiz-offline-snapshot.yml
+++ b/.github/workflows/postiz-offline-snapshot.yml
@@ -1,0 +1,69 @@
+name: Snapshot Postiz Offline
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/postiz-offline-snapshot.yml'
+      - 'postiz-stack/windows/INSTALLA_POSTIZ_WINDOWS.ps1'
+      - 'postiz-stack/windows/BACKUP_POSTIZ_WINDOWS.ps1'
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    env:
+      POSTIZ_VERSION: v2.22.1
+      COMPOSE_COMMIT: dd4969e5e694cd009619a0d53cff14c21104580b
+      RELEASE_TAG: postiz-offline-v2.22.1
+    steps:
+      - name: Checkout Open Social Scheduler
+        uses: actions/checkout@v4
+
+      - name: Create independent Postiz source bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone --branch "$POSTIZ_VERSION" https://github.com/gitroomhq/postiz-app.git postiz-app
+          git -C postiz-app bundle create "../postiz-app-${POSTIZ_VERSION}.bundle" --all
+
+      - name: Create independent Docker Compose bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone https://github.com/gitroomhq/postiz-docker-compose.git postiz-docker-compose
+          git -C postiz-docker-compose checkout --detach "$COMPOSE_COMMIT"
+          git -C postiz-docker-compose bundle create ../postiz-docker-compose.bundle --all
+
+      - name: Create manifest and checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > postiz-offline-manifest.txt <<EOF
+          Open Social Scheduler - independent Postiz recovery snapshot
+          Postiz version: ${POSTIZ_VERSION}
+          Docker Compose commit: ${COMPOSE_COMMIT}
+          Created by: ${GITHUB_REPOSITORY}@${GITHUB_SHA}
+          EOF
+          sha256sum "postiz-app-${POSTIZ_VERSION}.bundle" postiz-docker-compose.bundle > SHA256SUMS.txt
+
+      - name: Publish recovery release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
+              --title "Postiz offline recovery ${POSTIZ_VERSION}" \
+              --notes "Independent source snapshots used by Open Social Scheduler for disaster recovery. Upstream license notices remain inside the source bundle."
+          fi
+          gh release upload "$RELEASE_TAG" \
+            "postiz-app-${POSTIZ_VERSION}.bundle" \
+            postiz-docker-compose.bundle \
+            postiz-offline-manifest.txt \
+            SHA256SUMS.txt \
+            --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,14 @@
 *.env
 !*.env.example
 postiz-stack/postiz.env
+postiz-stack/windows/postiz.env
 
 # Cloned upstream sources (kept separate from OSS code)
 postiz-stack/vendor/
+
+# Local disaster-recovery snapshots (can be synced to Google Drive)
+postiz-stack/offline-backups/
+postiz-stack/windows/offline-backups/
 
 # Generated social media
 publisher/media/generated/

--- a/postiz-stack/windows/ATTIVA_BACKUP_AUTOMATICO_POSTIZ_WINDOWS.bat
+++ b/postiz-stack/windows/ATTIVA_BACKUP_AUTOMATICO_POSTIZ_WINDOWS.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+title Open Social Scheduler - Backup automatico Postiz
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0ATTIVA_BACKUP_AUTOMATICO_POSTIZ_WINDOWS.ps1"
+if errorlevel 1 (
+  echo.
+  echo ERRORE durante la configurazione del backup automatico.
+  pause
+  exit /b 1
+)
+echo.
+echo Backup automatico attivato.
+pause

--- a/postiz-stack/windows/ATTIVA_BACKUP_AUTOMATICO_POSTIZ_WINDOWS.ps1
+++ b/postiz-stack/windows/ATTIVA_BACKUP_AUTOMATICO_POSTIZ_WINDOWS.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = 'Stop'
+
+$TaskName = 'Open Social Scheduler - Backup Postiz'
+$BackupScript = Join-Path $PSScriptRoot 'BACKUP_POSTIZ_WINDOWS.ps1'
+
+if (-not (Test-Path $BackupScript)) {
+    throw "Script backup non trovato: $BackupScript"
+}
+
+$arguments = "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$BackupScript`" -SkipDockerImages"
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $arguments
+$trigger = New-ScheduledTaskTrigger -Daily -At 3:00AM
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -MultipleInstances IgnoreNew -ExecutionTimeLimit (New-TimeSpan -Hours 3)
+
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Settings $settings -Description 'Backup giornaliero dati Postiz/Open Social Scheduler. Le immagini Docker sono gia conservate nel backup completo iniziale.' -Force | Out-Null
+
+Write-Host "Backup automatico attivato: ogni giorno alle 03:00."
+Write-Host "Task Scheduler: $TaskName"

--- a/postiz-stack/windows/BACKUP_POSTIZ_WINDOWS.bat
+++ b/postiz-stack/windows/BACKUP_POSTIZ_WINDOWS.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+title Open Social Scheduler - Backup Postiz
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0BACKUP_POSTIZ_WINDOWS.ps1"
+if errorlevel 1 (
+  echo.
+  echo ERRORE durante il backup.
+  pause
+  exit /b 1
+)
+echo.
+echo Backup completato.
+pause

--- a/postiz-stack/windows/BACKUP_POSTIZ_WINDOWS.ps1
+++ b/postiz-stack/windows/BACKUP_POSTIZ_WINDOWS.ps1
@@ -77,12 +77,12 @@ if (Test-Path $ComposeFile) {
     Copy-Item $ComposeFile (Join-Path $BackupDir 'docker-compose.yaml') -Force
 }
 
-# 3) Databases and media. These contain the operational state needed to continue publishing.
+# 3) Databases and media. Dumps are restorable into a clean host.
 if ((docker ps --format '{{.Names}}') -contains 'postiz-postgres') {
-    & docker exec postiz-postgres pg_dump -U postiz-user -d postiz-db-local | Set-Content -Encoding UTF8 (Join-Path $BackupDir 'postiz-db.sql')
+    & docker exec postiz-postgres pg_dump --clean --if-exists --create -U postiz-user -d postiz-db-local | Set-Content -Encoding UTF8 (Join-Path $BackupDir 'postiz-db.sql')
 }
 if ((docker ps --format '{{.Names}}') -contains 'temporal-postgresql') {
-    & docker exec temporal-postgresql pg_dumpall -U temporal | Set-Content -Encoding UTF8 (Join-Path $BackupDir 'temporal-db.sql')
+    & docker exec temporal-postgresql pg_dumpall --clean --if-exists -U temporal | Set-Content -Encoding UTF8 (Join-Path $BackupDir 'temporal-db.sql')
 }
 if ((docker ps --format '{{.Names}}') -contains 'postiz-redis') {
     & docker exec postiz-redis redis-cli SAVE | Out-Null

--- a/postiz-stack/windows/BACKUP_POSTIZ_WINDOWS.ps1
+++ b/postiz-stack/windows/BACKUP_POSTIZ_WINDOWS.ps1
@@ -1,0 +1,130 @@
+param(
+    [string]$Destination = '',
+    [switch]$SkipDockerImages
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$StackRoot = Join-Path $RepoRoot 'postiz-stack'
+$Vendor = Join-Path $StackRoot 'vendor'
+$SourceRepo = Join-Path $Vendor 'postiz-app'
+$ComposeRepo = Join-Path $Vendor 'postiz-docker-compose'
+$ComposeFile = Join-Path $ComposeRepo 'docker-compose.yaml'
+$OverrideFile = Join-Path $StackRoot 'docker-compose.override.yml'
+$EnvFile = Join-Path $PSScriptRoot 'postiz.env'
+
+function Find-BackupRoot {
+    param([string]$Explicit)
+    if ($Explicit) {
+        return $Explicit
+    }
+    if ($env:OPEN_SOCIAL_BACKUP_DIR) {
+        return $env:OPEN_SOCIAL_BACKUP_DIR
+    }
+
+    $candidates = @(
+        (Join-Path $env:USERPROFILE 'Google Drive\Il mio Drive'),
+        (Join-Path $env:USERPROFILE 'Google Drive\My Drive')
+    )
+
+    foreach ($drive in Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue) {
+        $candidates += (Join-Path $drive.Root 'Il mio Drive')
+        $candidates += (Join-Path $drive.Root 'My Drive')
+    }
+
+    foreach ($candidate in $candidates | Select-Object -Unique) {
+        if ($candidate -and (Test-Path $candidate)) {
+            return (Join-Path $candidate 'Open Social Scheduler Backups\Postiz')
+        }
+    }
+
+    return (Join-Path $StackRoot 'offline-backups')
+}
+
+foreach ($cmd in @('git','docker')) {
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+        throw "$cmd non trovato."
+    }
+}
+if (-not (docker info 2>$null)) {
+    throw 'Docker Desktop non e attivo.'
+}
+
+$BackupRoot = Find-BackupRoot -Explicit $Destination
+$Stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$BackupDir = Join-Path $BackupRoot $Stamp
+New-Item -ItemType Directory -Force -Path $BackupDir | Out-Null
+
+Write-Host "Backup Postiz: $BackupDir"
+
+# 1) Source-code snapshots: independent git bundles.
+if (Test-Path (Join-Path $SourceRepo '.git')) {
+    & git -C $SourceRepo bundle create (Join-Path $BackupDir 'postiz-app.bundle') --all
+}
+if (Test-Path (Join-Path $ComposeRepo '.git')) {
+    & git -C $ComposeRepo bundle create (Join-Path $BackupDir 'postiz-docker-compose.bundle') --all
+}
+
+# 2) Runtime configuration. Secrets are encrypted with Windows DPAPI for the current user.
+if (Test-Path $EnvFile) {
+    $plain = Get-Content -Raw $EnvFile
+    $secure = ConvertTo-SecureString $plain -AsPlainText -Force
+    $cipher = ConvertFrom-SecureString $secure
+    Set-Content -Encoding UTF8 -Path (Join-Path $BackupDir 'postiz.env.dpapi') -Value $cipher
+}
+Copy-Item $OverrideFile (Join-Path $BackupDir 'docker-compose.override.yml') -Force
+if (Test-Path $ComposeFile) {
+    Copy-Item $ComposeFile (Join-Path $BackupDir 'docker-compose.yaml') -Force
+}
+
+# 3) Databases and media. These contain the operational state needed to continue publishing.
+if ((docker ps --format '{{.Names}}') -contains 'postiz-postgres') {
+    & docker exec postiz-postgres pg_dump -U postiz-user -d postiz-db-local | Set-Content -Encoding UTF8 (Join-Path $BackupDir 'postiz-db.sql')
+}
+if ((docker ps --format '{{.Names}}') -contains 'temporal-postgresql') {
+    & docker exec temporal-postgresql pg_dumpall -U temporal | Set-Content -Encoding UTF8 (Join-Path $BackupDir 'temporal-db.sql')
+}
+if ((docker ps --format '{{.Names}}') -contains 'postiz-redis') {
+    & docker exec postiz-redis redis-cli SAVE | Out-Null
+    & docker cp 'postiz-redis:/data/dump.rdb' (Join-Path $BackupDir 'redis-dump.rdb') | Out-Null
+}
+if ((docker ps --format '{{.Names}}') -contains 'postiz') {
+    New-Item -ItemType Directory -Force -Path (Join-Path $BackupDir 'postiz-files') | Out-Null
+    try { & docker cp 'postiz:/uploads' (Join-Path $BackupDir 'postiz-files\uploads') | Out-Null } catch { Write-Warning 'Backup /uploads non disponibile.' }
+    try { & docker cp 'postiz:/config' (Join-Path $BackupDir 'postiz-files\config') | Out-Null } catch { Write-Warning 'Backup /config non disponibile.' }
+}
+
+# 4) Save every Docker image required by the current compose stack.
+$images = @()
+if ((Test-Path $ComposeFile) -and (Test-Path $EnvFile)) {
+    $images = @(& docker compose --env-file $EnvFile -f $ComposeFile -f $OverrideFile config --images 2>$null) | Where-Object { $_ } | Sort-Object -Unique
+}
+if (-not $SkipDockerImages -and $images.Count -gt 0) {
+    & docker save -o (Join-Path $BackupDir 'docker-images.tar') @images
+}
+
+$sourceCommit = if (Test-Path (Join-Path $SourceRepo '.git')) { (& git -C $SourceRepo rev-parse HEAD).Trim() } else { $null }
+$composeCommit = if (Test-Path (Join-Path $ComposeRepo '.git')) { (& git -C $ComposeRepo rev-parse HEAD).Trim() } else { $null }
+$manifest = [ordered]@{
+    created_at = (Get-Date).ToString('o')
+    computer = $env:COMPUTERNAME
+    user = $env:USERNAME
+    postiz_version = 'v2.22.1'
+    postiz_source_commit = $sourceCommit
+    compose_commit = $composeCommit
+    docker_images = $images
+    contains_docker_images = (-not $SkipDockerImages -and (Test-Path (Join-Path $BackupDir 'docker-images.tar')))
+    contains_postiz_db = (Test-Path (Join-Path $BackupDir 'postiz-db.sql'))
+    contains_temporal_db = (Test-Path (Join-Path $BackupDir 'temporal-db.sql'))
+    env_encryption = 'Windows DPAPI current-user'
+}
+$manifest | ConvertTo-Json -Depth 5 | Set-Content -Encoding UTF8 (Join-Path $BackupDir 'manifest.json')
+
+# Pointer used by the installer/restore scripts.
+New-Item -ItemType Directory -Force -Path $BackupRoot | Out-Null
+Set-Content -Encoding UTF8 -Path (Join-Path $BackupRoot 'LATEST.txt') -Value $BackupDir
+
+Write-Host ''
+Write-Host 'BACKUP COMPLETATO.'
+Write-Host "Cartella: $BackupDir"
+Write-Host 'Questo snapshot consente di ripristinare Postiz anche se repository o immagini upstream non fossero piu disponibili.'

--- a/postiz-stack/windows/INSTALLA_POSTIZ_WINDOWS.ps1
+++ b/postiz-stack/windows/INSTALLA_POSTIZ_WINDOWS.ps1
@@ -9,6 +9,7 @@ $ComposeFile = Join-Path $ComposeRepo 'docker-compose.yaml'
 $OverrideFile = Join-Path $StackRoot 'docker-compose.override.yml'
 $EnvFile = Join-Path $PSScriptRoot 'postiz.env'
 $BackupScript = Join-Path $PSScriptRoot 'BACKUP_POSTIZ_WINDOWS.ps1'
+$ScheduleScript = Join-Path $PSScriptRoot 'ATTIVA_BACKUP_AUTOMATICO_POSTIZ_WINDOWS.ps1'
 $BaseUrl = 'http://localhost:4007'
 $PostizVersion = 'v2.22.1'
 $ComposeCommit = 'dd4969e5e694cd009619a0d53cff14c21104580b'
@@ -157,6 +158,15 @@ if (Test-Path $BackupScript) {
         & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $BackupScript
     } catch {
         Write-Warning "Postiz e avviato, ma il backup iniziale non e riuscito: $($_.Exception.Message)"
+    }
+}
+
+# Daily data backup. Docker images remain pinned and are already included in the initial full snapshot.
+if (Test-Path $ScheduleScript) {
+    try {
+        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $ScheduleScript
+    } catch {
+        Write-Warning "Backup automatico non registrato: $($_.Exception.Message). Puoi eseguire ATTIVA_BACKUP_AUTOMATICO_POSTIZ_WINDOWS.bat."
     }
 }
 

--- a/postiz-stack/windows/INSTALLA_POSTIZ_WINDOWS.ps1
+++ b/postiz-stack/windows/INSTALLA_POSTIZ_WINDOWS.ps1
@@ -3,13 +3,18 @@ $ErrorActionPreference = 'Stop'
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
 $StackRoot = Join-Path $RepoRoot 'postiz-stack'
 $Vendor = Join-Path $StackRoot 'vendor'
+$SourceRepo = Join-Path $Vendor 'postiz-app'
 $ComposeRepo = Join-Path $Vendor 'postiz-docker-compose'
 $ComposeFile = Join-Path $ComposeRepo 'docker-compose.yaml'
 $OverrideFile = Join-Path $StackRoot 'docker-compose.override.yml'
 $EnvFile = Join-Path $PSScriptRoot 'postiz.env'
+$BackupScript = Join-Path $PSScriptRoot 'BACKUP_POSTIZ_WINDOWS.ps1'
 $BaseUrl = 'http://localhost:4007'
+$PostizVersion = 'v2.22.1'
+$ComposeCommit = 'dd4969e5e694cd009619a0d53cff14c21104580b'
 
 Write-Host '=== OPEN SOCIAL SCHEDULER / POSTIZ - WINDOWS ==='
+Write-Host 'Modalita: SELF-HOSTED + RECOVERY LOCALE'
 
 foreach ($cmd in @('git','docker')) {
     if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
@@ -30,13 +35,59 @@ if (-not (docker info 2>$null)) {
     throw 'Docker Desktop non e ancora attivo.'
 }
 
+function Get-LatestBackup {
+    $roots = @()
+    if ($env:OPEN_SOCIAL_BACKUP_DIR) { $roots += $env:OPEN_SOCIAL_BACKUP_DIR }
+    $roots += (Join-Path $StackRoot 'offline-backups')
+    $roots += (Join-Path $env:USERPROFILE 'Google Drive\Il mio Drive\Open Social Scheduler Backups\Postiz')
+    $roots += (Join-Path $env:USERPROFILE 'Google Drive\My Drive\Open Social Scheduler Backups\Postiz')
+    foreach ($drive in Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue) {
+        $roots += (Join-Path $drive.Root 'Il mio Drive\Open Social Scheduler Backups\Postiz')
+        $roots += (Join-Path $drive.Root 'My Drive\Open Social Scheduler Backups\Postiz')
+    }
+    foreach ($root in $roots | Select-Object -Unique) {
+        if (-not $root -or -not (Test-Path $root)) { continue }
+        $pointer = Join-Path $root 'LATEST.txt'
+        if (Test-Path $pointer) {
+            $candidate = (Get-Content -Raw $pointer).Trim()
+            if ($candidate -and (Test-Path $candidate)) { return $candidate }
+        }
+        $candidate = Get-ChildItem $root -Directory -ErrorAction SilentlyContinue | Sort-Object Name -Descending | Select-Object -First 1 -ExpandProperty FullName
+        if ($candidate) { return $candidate }
+    }
+    return $null
+}
+
+$LatestBackup = Get-LatestBackup
 New-Item -ItemType Directory -Force -Path $Vendor | Out-Null
+
+# 1) Compose: prefer our own offline bundle. Only use upstream on first install if no backup exists.
 if (-not (Test-Path (Join-Path $ComposeRepo '.git'))) {
-    Write-Host 'Clone Docker Compose ufficiale Postiz ...'
-    git clone --depth 1 https://github.com/gitroomhq/postiz-docker-compose.git $ComposeRepo
+    $composeBundle = if ($LatestBackup) { Join-Path $LatestBackup 'postiz-docker-compose.bundle' } else { $null }
+    if ($composeBundle -and (Test-Path $composeBundle)) {
+        Write-Host 'Ripristino Docker Compose Postiz dalla NOSTRA copia offline ...'
+        git clone $composeBundle $ComposeRepo
+    } else {
+        Write-Host 'Prima installazione: clono Docker Compose ufficiale Postiz ...'
+        git clone https://github.com/gitroomhq/postiz-docker-compose.git $ComposeRepo
+        git -C $ComposeRepo checkout --detach $ComposeCommit
+    }
 } else {
-    Write-Host 'Aggiorno Docker Compose ufficiale Postiz ...'
-    git -C $ComposeRepo pull --ff-only
+    Write-Host 'Uso Docker Compose Postiz gia salvato localmente. Nessun pull automatico.'
+}
+
+# 2) Source code: keep a pinned independent local copy for audit/recovery/development.
+if (-not (Test-Path (Join-Path $SourceRepo '.git'))) {
+    $sourceBundle = if ($LatestBackup) { Join-Path $LatestBackup 'postiz-app.bundle' } else { $null }
+    if ($sourceBundle -and (Test-Path $sourceBundle)) {
+        Write-Host 'Ripristino sorgente Postiz dalla NOSTRA copia offline ...'
+        git clone $sourceBundle $SourceRepo
+    } else {
+        Write-Host "Prima installazione: salvo sorgente Postiz $PostizVersion ..."
+        git clone --depth 1 --branch $PostizVersion https://github.com/gitroomhq/postiz-app.git $SourceRepo
+    }
+} else {
+    Write-Host 'Uso sorgente Postiz gia salvato localmente. Nessun aggiornamento automatico.'
 }
 
 if (-not (Test-Path $ComposeFile)) {
@@ -76,6 +127,19 @@ OPENAI_API_KEY=
     Write-Host "Uso configurazione esistente $EnvFile"
 }
 
+# If the image disappeared upstream but we already have our recovery archive, load it first.
+$imageExists = $false
+try {
+    $imageExists = [bool](docker image inspect 'ghcr.io/gitroomhq/postiz-app:v2.22.1' 2>$null)
+} catch { $imageExists = $false }
+if (-not $imageExists -and $LatestBackup) {
+    $imagesTar = Join-Path $LatestBackup 'docker-images.tar'
+    if (Test-Path $imagesTar) {
+        Write-Host 'Carico le immagini Docker dalla NOSTRA copia offline ...'
+        docker load -i $imagesTar
+    }
+}
+
 $env:POSTIZ_STACK_DIR = $StackRoot
 Write-Host 'Avvio Postiz ...'
 docker compose --env-file $EnvFile -f $ComposeFile -f $OverrideFile up -d
@@ -84,3 +148,17 @@ docker compose --env-file $EnvFile -f $ComposeFile -f $OverrideFile ps
 Write-Host ''
 Write-Host 'POSTIZ LOCALE: http://localhost:4007'
 Write-Host 'Il dominio pubblico verra configurato in seguito con Cloudflare Tunnel.'
+
+# Create one complete recovery snapshot immediately after a successful installation.
+if (Test-Path $BackupScript) {
+    Write-Host ''
+    Write-Host 'Creo la copia di sicurezza indipendente da Postiz/GitHub ...'
+    try {
+        & powershell.exe -NoProfile -ExecutionPolicy Bypass -File $BackupScript
+    } catch {
+        Write-Warning "Postiz e avviato, ma il backup iniziale non e riuscito: $($_.Exception.Message)"
+    }
+}
+
+Write-Host ''
+Write-Host 'INSTALLAZIONE COMPLETATA: il runtime resta locale e non esegue aggiornamenti automatici dall upstream.'

--- a/postiz-stack/windows/RESTORE_POSTIZ_WINDOWS.ps1
+++ b/postiz-stack/windows/RESTORE_POSTIZ_WINDOWS.ps1
@@ -1,0 +1,142 @@
+param(
+    [string]$Backup = '',
+    [string]$BackupRoot = '',
+    [switch]$RestoreSecrets
+)
+
+$ErrorActionPreference = 'Stop'
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$StackRoot = Join-Path $RepoRoot 'postiz-stack'
+$Vendor = Join-Path $StackRoot 'vendor'
+$SourceRepo = Join-Path $Vendor 'postiz-app'
+$ComposeRepo = Join-Path $Vendor 'postiz-docker-compose'
+$ComposeFile = Join-Path $ComposeRepo 'docker-compose.yaml'
+$OverrideFile = Join-Path $StackRoot 'docker-compose.override.yml'
+$EnvFile = Join-Path $PSScriptRoot 'postiz.env'
+
+function Find-BackupRoot {
+    param([string]$Explicit)
+    if ($Explicit) { return $Explicit }
+    if ($env:OPEN_SOCIAL_BACKUP_DIR) { return $env:OPEN_SOCIAL_BACKUP_DIR }
+
+    $candidates = @(
+        (Join-Path $env:USERPROFILE 'Google Drive\Il mio Drive\Open Social Scheduler Backups\Postiz'),
+        (Join-Path $env:USERPROFILE 'Google Drive\My Drive\Open Social Scheduler Backups\Postiz'),
+        (Join-Path $StackRoot 'offline-backups')
+    )
+    foreach ($drive in Get-PSDrive -PSProvider FileSystem -ErrorAction SilentlyContinue) {
+        $candidates += (Join-Path $drive.Root 'Il mio Drive\Open Social Scheduler Backups\Postiz')
+        $candidates += (Join-Path $drive.Root 'My Drive\Open Social Scheduler Backups\Postiz')
+    }
+    foreach ($candidate in $candidates | Select-Object -Unique) {
+        if ($candidate -and (Test-Path $candidate)) { return $candidate }
+    }
+    throw 'Nessuna cartella backup Postiz trovata.'
+}
+
+foreach ($cmd in @('git','docker')) {
+    if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) { throw "$cmd non trovato." }
+}
+if (-not (docker info 2>$null)) { throw 'Docker Desktop non e attivo.' }
+
+if (-not $Backup) {
+    $root = Find-BackupRoot -Explicit $BackupRoot
+    $latestPointer = Join-Path $root 'LATEST.txt'
+    if (Test-Path $latestPointer) {
+        $Backup = (Get-Content -Raw $latestPointer).Trim()
+    } else {
+        $Backup = Get-ChildItem $root -Directory | Sort-Object Name -Descending | Select-Object -First 1 -ExpandProperty FullName
+    }
+}
+if (-not $Backup -or -not (Test-Path $Backup)) { throw "Backup non trovato: $Backup" }
+
+Write-Host "=== RIPRISTINO POSTIZ ==="
+Write-Host "Snapshot: $Backup"
+New-Item -ItemType Directory -Force -Path $Vendor | Out-Null
+
+# Restore source repositories from our own offline bundles first.
+$sourceBundle = Join-Path $Backup 'postiz-app.bundle'
+$composeBundle = Join-Path $Backup 'postiz-docker-compose.bundle'
+if (-not (Test-Path (Join-Path $SourceRepo '.git')) -and (Test-Path $sourceBundle)) {
+    & git clone $sourceBundle $SourceRepo
+}
+if (-not (Test-Path (Join-Path $ComposeRepo '.git')) -and (Test-Path $composeBundle)) {
+    & git clone $composeBundle $ComposeRepo
+}
+
+# Fallback compose file saved in the snapshot, even if the git bundle is unavailable.
+if (-not (Test-Path $ComposeFile)) {
+    $savedCompose = Join-Path $Backup 'docker-compose.yaml'
+    if (-not (Test-Path $savedCompose)) { throw 'docker-compose.yaml non disponibile nel backup.' }
+    New-Item -ItemType Directory -Force -Path $ComposeRepo | Out-Null
+    Copy-Item $savedCompose $ComposeFile -Force
+}
+
+$imagesTar = Join-Path $Backup 'docker-images.tar'
+if (Test-Path $imagesTar) {
+    Write-Host 'Carico le immagini Docker dalla nostra copia offline ...'
+    & docker load -i $imagesTar
+}
+
+# Restore encrypted env only on the same Windows user/machine unless explicitly requested.
+$encryptedEnv = Join-Path $Backup 'postiz.env.dpapi'
+if ($RestoreSecrets -and (Test-Path $encryptedEnv)) {
+    try {
+        $cipher = (Get-Content -Raw $encryptedEnv).Trim()
+        $secure = ConvertTo-SecureString $cipher
+        $ptr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+        try { $plain = [Runtime.InteropServices.Marshal]::PtrToStringBSTR($ptr) }
+        finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($ptr) }
+        Set-Content -Encoding UTF8 -Path $EnvFile -Value $plain
+        Write-Host 'Configurazione segreta ripristinata tramite Windows DPAPI.'
+    } catch {
+        Write-Warning 'Impossibile decifrare postiz.env.dpapi su questo utente/computer. Mantengo la configurazione esistente.'
+    }
+}
+if (-not (Test-Path $EnvFile)) {
+    throw 'postiz.env mancante. Se il backup proviene dallo stesso utente Windows rilancia con -RestoreSecrets.'
+}
+
+$env:POSTIZ_STACK_DIR = $StackRoot
+
+# Start only infrastructure first, restore state, then start the application.
+& docker compose --env-file $EnvFile -f $ComposeFile -f $OverrideFile up -d postiz-postgres postiz-redis temporal-postgresql temporal-elasticsearch temporal
+Start-Sleep -Seconds 5
+
+$postizSql = Join-Path $Backup 'postiz-db.sql'
+if (Test-Path $postizSql) {
+    Write-Host 'Ripristino database Postiz ...'
+    $cmd = "type `"$postizSql`" | docker exec -i postiz-postgres psql -U postiz-user -d postgres"
+    cmd /c $cmd
+}
+
+$temporalSql = Join-Path $Backup 'temporal-db.sql'
+if (Test-Path $temporalSql) {
+    Write-Host 'Ripristino database Temporal ...'
+    $cmd = "type `"$temporalSql`" | docker exec -i temporal-postgresql psql -U temporal -d postgres"
+    cmd /c $cmd
+}
+
+$redisDump = Join-Path $Backup 'redis-dump.rdb'
+if (Test-Path $redisDump) {
+    & docker stop postiz-redis | Out-Null
+    & docker cp $redisDump 'postiz-redis:/data/dump.rdb' | Out-Null
+    & docker start postiz-redis | Out-Null
+}
+
+& docker compose --env-file $EnvFile -f $ComposeFile -f $OverrideFile up -d
+
+$filesRoot = Join-Path $Backup 'postiz-files'
+if ((Test-Path $filesRoot) -and ((docker ps --format '{{.Names}}') -contains 'postiz')) {
+    if (Test-Path (Join-Path $filesRoot 'uploads')) {
+        & docker cp (Join-Path $filesRoot 'uploads\.') 'postiz:/uploads/' | Out-Null
+    }
+    if (Test-Path (Join-Path $filesRoot 'config')) {
+        & docker cp (Join-Path $filesRoot 'config\.') 'postiz:/config/' | Out-Null
+    }
+    & docker restart postiz | Out-Null
+}
+
+Write-Host ''
+Write-Host 'RIPRISTINO COMPLETATO.'
+Write-Host 'Postiz usa ora codice, dati e immagini conservati nella nostra copia di sicurezza.'

--- a/postiz-stack/windows/RIPRISTINA_POSTIZ_WINDOWS.bat
+++ b/postiz-stack/windows/RIPRISTINA_POSTIZ_WINDOWS.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+title Open Social Scheduler - Ripristino Postiz
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0RESTORE_POSTIZ_WINDOWS.ps1" -RestoreSecrets
+if errorlevel 1 (
+  echo.
+  echo ERRORE durante il ripristino.
+  pause
+  exit /b 1
+)
+echo.
+echo Ripristino completato.
+pause


### PR DESCRIPTION
## Cosa cambia
- blocca gli aggiornamenti automatici dell'upstream Postiz sul runtime Windows
- mantiene una copia locale fissata di Postiz v2.22.1 e del Docker Compose associato
- crea un backup completo iniziale con sorgente, immagini Docker, database, Redis, upload e configurazione cifrata
- aggiunge ripristino offline con un doppio clic
- registra un backup dati giornaliero alle 03:00
- aggiunge un workflow GitHub che pubblica bundle sorgente di recovery sotto questo repository

## Perché
L'obiettivo è evitare che la scomparsa del servizio/repository Postiz costringa Open Social Scheduler a tornare alla pubblicazione manuale.

## Impatto
Il motore contenuti e i dati clienti non vengono modificati. Le modifiche riguardano esclusivamente il runtime Postiz e la disaster recovery.